### PR TITLE
update random seed in example test

### DIFF
--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -15,8 +15,8 @@ func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
 
 	rand.Seed(time.Now().UnixNano())
-	randId := strconv.Itoa(rand.Intn(100000))
-	attributes := []string{randId}
+	randID := strconv.Itoa(rand.Intn(100000))
+	attributes := []string{randID}
 
 	exampleInput := "Hello, world!"
 
@@ -48,7 +48,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Ensure we get a random number appended
 	assert.Equal(t, exampleInput+" "+random, example)
 	// Ensure we get the attribute included in the ID
-	assert.Equal(t, "eg-ue2-test-example-"+randId, id)
+	assert.Equal(t, "eg-ue2-test-example-"+randID, id)
 
 	// ************************************************************************
 	// This steps below are unusual, not generally part of the testing

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ import (
 func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
 
+	rand.Seed(time.Now().UnixNano())
 	randId := strconv.Itoa(rand.Intn(100000))
 	attributes := []string{randId}
 


### PR DESCRIPTION
## what
* update the random number generator with a seed 

## why
* The `rand` package generates pseudo-random numbers, which are generated based on a specific initial value (called "seed"). Without providing an initial seed value, you'll likely generate the same number over and over again, which defeats the purpose of using it here in the tests.

## references
* Go [math/rand](https://golang.org/pkg/math/rand/)

