### PR TITLE
Autoclose the dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
-  // config:base enables the dependency dashboard and this will close the open ticket if there aren't any open dependency PRs open
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,8 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  // config:base enables the dependency dashboard and this will close the open ticket if there aren't any open dependency PRs open
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]


### PR DESCRIPTION
## what
* Autoclose the dependency dashboard

## why
* The config:base preset enables the dependency dashboard and this will auto close it if there aren't any open dependency related PRs

## references
* https://docs.renovatebot.com/presets-config/#configbase

