### PR TITLE
Fix feature branch workflow

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/v*
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## what

* Do not trigger feature branch workflow on `label` `unlabel`

## why

* There is no operation that we need to perform on labels